### PR TITLE
:package: created service response time limiter - #18

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const cors = require('cors'),
     morgan = require('morgan'),
     path = require('path'),
     configs = require('./configs/config'),
-    rateLimiter = require('./middlewares/rateLimiter')
+    rateLimiter = require('./middlewares/rateLimiter'),
+    responseTimeLimiter = require('./middlewares/responseTimeLimiter')
 
 dotenv.config()
 const app = express()
@@ -34,6 +35,7 @@ const countingBloomService = require('./routes/countingbloomservice.route.js')
 app.use(cors())
 app.use(express.json())
 app.use(rateLimiter)
+app.use(responseTimeLimiter)
 app.use("/api", home, feedbackService)
 app.use("/bloomfilter", classicalBloomService)
 app.use("/countingbloomfilter", countingBloomService)

--- a/middlewares/rateLimiter.js
+++ b/middlewares/rateLimiter.js
@@ -1,8 +1,8 @@
 const expressLimit = require('express-rate-limit');
 
 let rateLimiter = expressLimit({
-    windowMs: 30 * 1000, // window size in ms
-    max: 5, // Limit each IP to 5 requests per window of 30sec.
+    windowMs: 60 * 1000, // 1min window
+    max: 20, // Limit each IP to 20 requests per window.
     standardHeaders: true,
     legacyHeaders: false,
 });

--- a/middlewares/responseTimeLimiter.js
+++ b/middlewares/responseTimeLimiter.js
@@ -1,0 +1,10 @@
+const expressSlowDown = require('express-slow-down');
+
+//After 15 requests in a 2min window, adds a subsequent response slow down of 500ms with each request.
+let responseTimeLimiter = expressSlowDown({
+    windowMs: 2 * 60 * 1000,
+    delayAfter: 15,
+    delayMs: 500
+})
+
+module.exports = responseTimeLimiter;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dotenv": "^16.0.0",
     "express": "^4.17.3",
     "express-rate-limit": "^6.7.0",
+    "express-slow-down": "^1.5.0",
     "morgan": "^1.10.0"
   }
 }


### PR DESCRIPTION
#18 Issue resolved.
* Configured API response time slow down by **500ms increments** in a 2-minute window. The **request limit is 15 requests** to trigger response delays of 500ms on subsequent requests.
* Made changes to API rate limiter - Allows **20 requests in a 1-minute** window per IP.